### PR TITLE
feat: 재료 조회 기능 구현

### DIFF
--- a/refrigerator/src/main/java/moja/refrigerator/controller/ingredient/IngredientController.java
+++ b/refrigerator/src/main/java/moja/refrigerator/controller/ingredient/IngredientController.java
@@ -1,12 +1,12 @@
 package moja.refrigerator.controller.ingredient;
 
 import moja.refrigerator.dto.ingredient.request.IngredientCreateRequest;
+import moja.refrigerator.dto.ingredient.response.IngredientResponse;
 import moja.refrigerator.service.ingredient.IngredientService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/ingredient")
@@ -18,8 +18,15 @@ public class IngredientController {
         this.ingredientService = ingredientService;
     }
 
+    // 재료 등록
     @PostMapping
     public void createIngredient(@RequestBody IngredientCreateRequest request) {
         ingredientService.createIngredient(request);
+    }
+
+    // 재료 조회
+    @GetMapping
+    public List<IngredientResponse> getIngredient() {
+        return ingredientService.getIngredient();
     }
 }

--- a/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/response/IngredientResponse.java
+++ b/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/response/IngredientResponse.java
@@ -1,0 +1,24 @@
+package moja.refrigerator.dto.ingredient.response;
+
+import lombok.Data;
+
+@Data
+public class IngredientResponse {
+    private long ingredientManagementPk;
+    private String ingredientName;
+    private String expirationDate;
+    private String registrationDate;
+    private int seasonDate;
+
+    // ModelMapper를 위한 기본 생성자 생성
+    public IngredientResponse() {}
+
+    // 생성자
+    public IngredientResponse(long ingredientManagementPk, String ingredientName, String expirationDate, String registrationDate, int seasonDate) {
+        this.ingredientManagementPk = ingredientManagementPk;
+        this.ingredientName = ingredientName;
+        this.expirationDate = expirationDate;
+        this.registrationDate = registrationDate;
+        this.seasonDate = seasonDate;
+    }
+}

--- a/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientService.java
+++ b/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientService.java
@@ -1,7 +1,11 @@
 package moja.refrigerator.service.ingredient;
 
 import moja.refrigerator.dto.ingredient.request.IngredientCreateRequest;
+import moja.refrigerator.dto.ingredient.response.IngredientResponse;
+
+import java.util.List;
 
 public interface IngredientService {
-    void createIngredient(IngredientCreateRequest request);
+    void createIngredient(IngredientCreateRequest request); // 재료 등록 메서드
+    List<IngredientResponse> getIngredient(); // 재료 조회 메서드
 }

--- a/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientServiceImpl.java
+++ b/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientServiceImpl.java
@@ -5,12 +5,16 @@ import moja.refrigerator.aggregate.ingredient.IngredientManagement;
 //import moja.refrigerator.aggregate.ingredient.IngredientStorage;
 import moja.refrigerator.dto.ingredient.request.IngredientCreateRequest;
 //import moja.refrigerator.repository.ingredient.IngredientCategoryRepository;
+import moja.refrigerator.dto.ingredient.response.IngredientResponse;
 import moja.refrigerator.repository.ingredient.IngredientManagementRepository;
 //import moja.refrigerator.repository.ingredient.IngredientStorageRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class IngredientServiceImpl implements IngredientService{
@@ -45,6 +49,18 @@ public class IngredientServiceImpl implements IngredientService{
 //        ingredient.setIngredientCategory(category);
 //        ingredient.setIngredientStorage(storage);
 
+        // 재료를 JpaRepository의 save() 메소드로 DB에 저장 !
         ingredientManagementRepository.save(ingredient);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<IngredientResponse> getIngredient() {
+        List<IngredientManagement> ingredients = ingredientManagementRepository.findAll();
+
+        return ingredients.stream()
+                .map(ingredient -> mapper.map(ingredient, IngredientResponse.class))
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
1. Controller에서 GetMapping 어노테이션으로 API 진입지점을 만들고 조회 메서드를 추가해주었습니다.
```
// 재료 조회
@GetMapping
public List<IngredientResponse> getIngredient() {
    return ingredientService.getIngredient();
}
```
2. IngredientResponse 클래스를 만들어 Entity와 DB가 매핑되는 객체로 유지될 수 있도록 계층분리를 해주었습니다.
 
3. IngredientService인터페이스에 조회 메서드를 만들어 주어서 함께 ServiceImpl에 상속될 수 있도록 하였습니다.
```
public interface IngredientService {
    void createIngredient(IngredientCreateRequest request); // 재료 등록 메서드
    List<IngredientResponse> getIngredient(); // 재료 조회 메서드
}
```
4. IngredientServiceImpl에서는 ModelMapper를 활용해서 등록한 모든 재료들을 조회할 수 있도록 하였습니다.
```
@Override
@Transactional(readOnly = true)
public List<IngredientResponse> getIngredient() {
    List<IngredientManagement> ingredients = ingredientManagementRepository.findAll();

    return ingredients.stream()
            .map(ingredient -> mapper.map(ingredient, IngredientResponse.class))
            .collect(Collectors.toList());
}
```
![image](https://github.com/user-attachments/assets/313be041-3d4f-4bc5-85ef-760bd3d6206b)
