### PR TITLE
fix: 유통기한 남은 일수 표시 및 정렬

### DIFF
--- a/refrigerator/.idea/dataSources.xml
+++ b/refrigerator/.idea/dataSources.xml
@@ -27,5 +27,19 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="test_refrigerator@localhost" uuid="d749dc9b-69dc-4cfd-b5c2-ea2348b5c790">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/src/main/resources/application.yml</remarks>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/test_refrigerator</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/response/IngredientResponse.java
+++ b/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/response/IngredientResponse.java
@@ -8,8 +8,9 @@ public class IngredientResponse {
     private int number;
     private long ingredientMyRefrigeratorPk;
     private String ingredientName;
-    private int ingredientAmount;
+    private float ingredientAmount;
     private String expirationDate;
+    private long remainExpirationDate;
     private int seasonDate;
     private String ingredientStorage;
 


### PR DESCRIPTION
## 📋 요약
- 재료 조회 시 현재 날짜 기준으로 유통 기한까지의 남은 일수를 표시 되도록 수정하였습니다.
- 남은 일수 기준으로 재료 조회시 오름차순 정렬되도록 하였습니다.
- 남은 일수는 remainExpirationDate로 표시 됩니다.

## 🛠 변경 사항
- 이번 Pull Request에서 작업한 주요 변경 사항은 다음과 같습니다:
  - [x] 코드 리팩토링 또는 최적화

## 🔗 관련 이슈
- 이 PR로 해결되는 이슈: #24 
- 관련된 이슈: #24 

## 📸 스크린샷 또는 GIF (해당되는 경우)
- 등록
![image](https://github.com/user-attachments/assets/60ca2c64-26ae-4298-a6b7-b215e735e4bf)

- 조회
![image](https://github.com/user-attachments/assets/e765346e-07ce-48f5-b2ee-7a55f1db5b77)

- 수정
![image](https://github.com/user-attachments/assets/e9cb96af-74db-4631-8071-f822dfbfa75b)

- 삭제
![image](https://github.com/user-attachments/assets/00fa82f1-e17c-4d97-983f-dc1c4451ca02)

## ✅ 체크리스트


## 🛡 테스트 방법


## 📚 추가 참고 사항
- ### POSTMAN 테스트 할 때 userPk 넣어서 테스트해본 결과 잘 작동 됩니다 !!
