### PR TITLE
fix: 재료 삭제 시 삭제할 수량 입력

### DIFF
--- a/refrigerator/src/main/java/moja/refrigerator/controller/ingredient/IngredientController.java
+++ b/refrigerator/src/main/java/moja/refrigerator/controller/ingredient/IngredientController.java
@@ -1,5 +1,6 @@
 package moja.refrigerator.controller.ingredient;
 
+import jakarta.persistence.EntityNotFoundException;
 import moja.refrigerator.dto.ingredient.request.*;
 import moja.refrigerator.dto.ingredient.response.*;
 import moja.refrigerator.service.ingredient.IngredientService;
@@ -44,8 +45,15 @@ public class IngredientController {
 
     // 재료 삭제
     @DeleteMapping
-    public void deleteIngredient(@RequestParam Long ingredientMyRefrigeratorPk) {
-        ingredientService.deleteIngredient(ingredientMyRefrigeratorPk);
+    public ResponseEntity<String> deleteIngredient(@RequestBody IngredientDeleteRequest request) {
+        try {
+            ingredientService.deleteIngredient(request);
+            return ResponseEntity.ok("재료가 성공적으로 삭제되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @PostMapping("/bookmark/regist")

--- a/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/request/IngredientDeleteRequest.java
+++ b/refrigerator/src/main/java/moja/refrigerator/dto/ingredient/request/IngredientDeleteRequest.java
@@ -1,0 +1,11 @@
+package moja.refrigerator.dto.ingredient.request;
+
+import lombok.Data;
+
+@Data
+public class IngredientDeleteRequest {
+
+    private Long ingredientMyRefrigeratorPk;
+    private float deleteAmount;
+
+}

--- a/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientService.java
+++ b/refrigerator/src/main/java/moja/refrigerator/service/ingredient/IngredientService.java
@@ -14,7 +14,7 @@ public interface IngredientService {
     List<IngredientResponse> getIngredient(Long userPk); // 재료 조회 메서드
     void updateIngredient(IngredientUpdateRequest request);
 
-    void deleteIngredient(long ingredientMyRefrigeratorPk);
+    void deleteIngredient(IngredientDeleteRequest request);
 
     List<ResponseUsersIngredientBookmarkLists> getUsersIngredientBookmarkLists(
             RequestIngredientBookmarkLists requestBookmarkLists);


### PR DESCRIPTION
## 📋 요약
- 원래는 재료 삭제할 때 수량에 상관 없이 바로 삭제가 되었지만, 재료 삭제 시 수량 입력 로직을 추가함
- 남아 있던 수량과 삭제 수량이 일치하면 해당 재료 완전 삭제
- 남아 있던 수량보다 삭제할 수량이 더 적다면 남아있는 수량이 자동 계산된 후 저장 됨

## 🛠 변경 사항
- 이번 Pull Request에서 작업한 주요 변경 사항은 다음과 같습니다:
  - [x] 코드 리팩토링 또는 최적화

## 🔗 관련 이슈
- 이 PR로 해결되는 이슈: #24 
- 관련된 이슈: #24 

## 📸 스크린샷 또는 GIF (해당되는 경우)
- 삭제
![image](https://github.com/user-attachments/assets/15e36f54-a556-412e-b9d1-039ec3f5650f)
삭제시 deleteAmount를  사용자가 직접 입력


## ✅ 체크리스트

## 🛡 테스트 방법

## 📚 추가 참고 사항
- 이 PR과 관련해 리뷰어가 알아야 할 추가 내용이 있다면 작성해주세요.
